### PR TITLE
Fix sync trigger in native versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,12 @@ commands:
           environment:
             DB: << parameters.db >>
           command: pytest
+databases-config:
+  postgres: &postgres-config
+    POSTGRES_DB: sqlalchemy_continuum_test
+  mysql: &mysql-config
+    MYSQL_DATABASE: sqlalchemy_continuum_test
+    MYSQL_ALLOW_EMPTY_PASSWORD: yes
 executors:
   python27:
     working_directory: ~/app
@@ -19,30 +25,30 @@ executors:
     - image: python:2.7
     - image: postgres:10
       environment:
-        POSTGRES_DB: sqlalchemy_continuum_test
-    - image: mysql:8
+        <<: *postgres-config
+    - image: mysql:5
       environment:
-        MYSQL_DATABASE: sqlalchemy_continuum_test
+        <<: *mysql-config
   python36:
     working_directory: ~/app
     docker:
     - image: python:3.6
     - image: postgres:10
       environment:
-        POSTGRES_DB: sqlalchemy_continuum_test
-    - image: mysql:8
+        <<: *postgres-config
+    - image: mysql:5
       environment:
-        MYSQL_DATABASE: sqlalchemy_continuum_test
+        <<: *mysql-config
   python37:
     working_directory: ~/app
     docker:
     - image: python:3.7
     - image: postgres:10
       environment:
-        POSTGRES_DB: sqlalchemy_continuum_test
-    - image: mysql:8
+        <<: *postgres-config
+    - image: mysql:5
       environment:
-        MYSQL_DATABASE: sqlalchemy_continuum_test
+        <<: *mysql-config
 jobs:
   test_sqlite:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+version: 2.1
+jobs:
+  test:
+    docker:
+      - image: python:2.7
+    working_directory: ~/app
+    steps:
+      - checkout
+      - run: pip install .[test]
+      - run: DB=sqlite pytest
+  release:
+    docker:
+      - image: python:2.7
+    working_directory: ~/app
+    steps:
+      - checkout
+      - run: |
+          pip install twine
+          pip install .
+      - run: |
+          python setup.py sdist
+          twine upload --repository-url https://geru-pypi.geru.com.br/ dist/*
+workflows:
+  version: 2
+  test-always:
+    jobs:
+      - test
+  test-and-release:
+    jobs:
+      - test
+      - release:
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,16 @@ executors:
     - image: mysql:8
       environment:
         MYSQL_DATABASE: sqlalchemy_continuum_test
+  python37:
+    working_directory: ~/app
+    docker:
+    - image: python:3.7
+    - image: postgres:10
+      environment:
+        POSTGRES_DB: sqlalchemy_continuum_test
+    - image: mysql:8
+      environment:
+        MYSQL_DATABASE: sqlalchemy_continuum_test
 jobs:
   test_sqlite:
     parameters:
@@ -106,14 +116,32 @@ workflows:
       - test_postgres-native:
           name: test_36_postgres-native
           run_with: python36
+      - test_sqlite:
+          name: test_37_sqlite
+          run_with: python37
+      - test_mysql:
+          name: test_37_mysql
+          run_with: python37
+      - test_postgres:
+          name: test_37_postgres
+          run_with: python37
+      - test_postgres-native:
+          name: test_37_postgres-native
+          run_with: python37
       - release:
           requires:
             - test_27_sqlite
+            - test_27_mysql
             - test_27_postgres
             - test_27_postgres-native
             - test_36_sqlite
+            - test_36_mysql
             - test_36_postgres
             - test_36_postgres-native
+            - test_37_sqlite
+            - test_37_mysql
+            - test_37_postgres
+            - test_37_postgres-native
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,57 @@
 version: 2.1
-jobs:
-  test:
-    docker:
-      - image: python:2.7
-    working_directory: ~/app
+commands:
+  build_and_test:
+    parameters:
+      db:
+        type: string
     steps:
+      - run: echo $(python --version) database=<< parameters.db >>
       - checkout
       - run: pip install .[test]
-      - run: DB=sqlite pytest
+      - run:
+          environment:
+            DB: << parameters.db >>
+          command: pytest
+executors:
+  python27:
+    working_directory: ~/app
+    docker:
+    - image: python:2.7
+    - image: postgres:10
+      environment:
+        POSTGRES_DB: sqlalchemy_continuum_test
+  python36:
+    working_directory: ~/app
+    docker:
+    - image: python:3.6
+    - image: postgres:10
+      environment:
+        POSTGRES_DB: sqlalchemy_continuum_test
+jobs:
+  test_sqlite:
+    parameters:
+      run_with:
+        type: string
+    executor: << parameters.run_with >>
+    steps:
+      - build_and_test:
+          db: sqlite
+  test_postgres:
+    parameters:
+      run_with:
+        type: string
+    executor: << parameters.run_with >>
+    steps:
+      - build_and_test:
+          db: postgres
+  test_postgres-native:
+    parameters:
+      run_with:
+        type: string
+    executor: << parameters.run_with >>
+    steps:
+      - build_and_test:
+          db: postgres-native
   release:
     docker:
       - image: python:2.7
@@ -22,15 +66,34 @@ jobs:
           twine upload --repository-url https://geru-pypi.geru.com.br/ dist/*
 workflows:
   version: 2
-  test-always:
+  test_and_maybe_release:
     jobs:
-      - test
-  test-and-release:
-    jobs:
-      - test
+      - test_sqlite:
+          name: test_27_sqlite
+          run_with: python27
+      - test_postgres:
+          name: test_27_postgres
+          run_with: python27
+      - test_postgres-native:
+          name: test_27_postgres-native
+          run_with: python27
+      - test_sqlite:
+          name: test_36_sqlite
+          run_with: python36
+      - test_postgres:
+          name: test_36_postgres
+          run_with: python36
+      - test_postgres-native:
+          name: test_36_postgres-native
+          run_with: python36
       - release:
           requires:
-            - test
+            - test_27_sqlite
+            - test_27_postgres
+            - test_27_postgres-native
+            - test_36_sqlite
+            - test_36_postgres
+            - test_36_postgres-native
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ executors:
     - image: postgres:10
       environment:
         POSTGRES_DB: sqlalchemy_continuum_test
+    - image: mysql:8
+      environment:
+        MYSQL_DATABASE: sqlalchemy_continuum_test
   python36:
     working_directory: ~/app
     docker:
@@ -27,6 +30,9 @@ executors:
     - image: postgres:10
       environment:
         POSTGRES_DB: sqlalchemy_continuum_test
+    - image: mysql:8
+      environment:
+        MYSQL_DATABASE: sqlalchemy_continuum_test
 jobs:
   test_sqlite:
     parameters:
@@ -36,6 +42,14 @@ jobs:
     steps:
       - build_and_test:
           db: sqlite
+  test_mysql:
+    parameters:
+      run_with:
+        type: string
+    executor: << parameters.run_with >>
+    steps:
+      - build_and_test:
+          db: mysql
   test_postgres:
     parameters:
       run_with:
@@ -71,6 +85,9 @@ workflows:
       - test_sqlite:
           name: test_27_sqlite
           run_with: python27
+      - test_mysql:
+          name: test_27_mysql
+          run_with: python27
       - test_postgres:
           name: test_27_postgres
           run_with: python27
@@ -79,6 +96,9 @@ workflows:
           run_with: python27
       - test_sqlite:
           name: test_36_sqlite
+          run_with: python36
+      - test_mysql:
+          name: test_36_mysql
           run_with: python36
       - test_postgres:
           name: test_36_postgres

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ nosetests.xml
 
 # idea
 .idea/
+
+# pyenv
+.python-version

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Changelog
 Here you can see the full list of changes between each SQLAlchemy-Continuum release.
 
 
+1.3.9+geru.1 (2019-06-03)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Support for downgrades (only drop trigger) in native_versioning
+- Support for customized version tables in native_versioning
+- Simpler use of sync_trigger (with table model) in native_versioning
+
+
 1.3.9 (2019-03-19)
 ^^^^^^^^^^^^^^^^^^
 

--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -18,7 +18,7 @@ from .utils import (
 )
 
 
-__version__ = '1.3.9'
+__version__ = '1.3.9+geru.1'
 
 
 versioning_manager = VersioningManager()

--- a/sqlalchemy_continuum/dialects/postgresql.py
+++ b/sqlalchemy_continuum/dialects/postgresql.py
@@ -1,6 +1,5 @@
 import sqlalchemy as sa
 
-from sqlalchemy_continuum import version_class
 from sqlalchemy_continuum.plugins import PropertyModTrackerPlugin
 
 
@@ -485,8 +484,10 @@ def sync_trigger(conn, table_model):
     except sa.exc.NoSuchTableError:
         return
 
+    from sqlalchemy_continuum import versioning_manager
+    version_pattern = versioning_manager.options['table_name']
     version_table = sa.Table(
-        version_class(parent_table),
+        version_pattern % table_model,
         meta,
         autoload=True,
         autoload_with=conn

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -44,7 +44,7 @@ def get_dns_from_driver(driver):
     if driver == 'postgres':
         return 'postgres://postgres@localhost/sqlalchemy_continuum_test'
     elif driver == 'mysql':
-        return 'mysql+pymysql://travis@localhost/sqlalchemy_continuum_test'
+        return 'mysql+pymysql://root@localhost/sqlalchemy_continuum_test'
     elif driver == 'sqlite':
         return 'sqlite:///:memory:'
     else:

--- a/tests/dialects/test_triggers.py
+++ b/tests/dialects/test_triggers.py
@@ -59,3 +59,12 @@ class TestTriggerSyncing(object):
             in QueryPool.queries[-2]
         )
         assert 'DROP FUNCTION ' in QueryPool.queries[-1]
+
+    def test_drop_triggers_using_sync(self):
+        self.connection.execute('DROP TABLE IF EXISTS article')
+        sync_trigger(self.connection, 'article')
+        assert (
+            'DROP TRIGGER IF EXISTS article_trigger ON "article"'
+            in QueryPool.queries[-3]
+        )
+        assert 'DROP FUNCTION ' in QueryPool.queries[-2]

--- a/tests/dialects/test_triggers.py
+++ b/tests/dialects/test_triggers.py
@@ -42,15 +42,15 @@ class TestTriggerSyncing(object):
         self.connection.close()
 
     def test_sync_triggers(self):
-        sync_trigger(self.connection, 'article_version')
+        sync_trigger(self.connection, 'article')
         assert (
             'DROP TRIGGER IF EXISTS article_trigger ON "article"'
-            in QueryPool.queries[-4]
+            in QueryPool.queries[3]
         )
-        assert 'DROP FUNCTION ' in QueryPool.queries[-3]
+        assert 'DROP FUNCTION ' in QueryPool.queries[4]
         assert 'CREATE OR REPLACE FUNCTION ' in QueryPool.queries[-2]
         assert 'CREATE TRIGGER ' in QueryPool.queries[-1]
-        sync_trigger(self.connection, 'article_version')
+        sync_trigger(self.connection, 'article')
 
     def test_drop_triggers(self):
         drop_trigger(self.connection, 'article')

--- a/tests/dialects/test_triggers.py
+++ b/tests/dialects/test_triggers.py
@@ -42,12 +42,13 @@ class TestTriggerSyncing(object):
         self.connection.close()
 
     def test_sync_triggers(self):
+        next_index = len(QueryPool.queries)
         sync_trigger(self.connection, 'article')
         assert (
             'DROP TRIGGER IF EXISTS article_trigger ON "article"'
-            in QueryPool.queries[3]
+            in QueryPool.queries[next_index]
         )
-        assert 'DROP FUNCTION ' in QueryPool.queries[4]
+        assert 'DROP FUNCTION ' in QueryPool.queries[next_index + 1]
         assert 'CREATE OR REPLACE FUNCTION ' in QueryPool.queries[-2]
         assert 'CREATE TRIGGER ' in QueryPool.queries[-1]
         sync_trigger(self.connection, 'article')


### PR DESCRIPTION
Part of https://geruteam.atlassian.net/browse/CORE-1569

This implements an enhanced version of sync_trigger, which includes:

- Support for downgrades (only drop trigger) in native_versioning
- Support for customized version tables in native_versioning
- Simpler use of sync_trigger (with table model) in native_versioning

Also mitigates bug: https://github.com/kvesteri/sqlalchemy-continuum/issues/115